### PR TITLE
fix: return promise that never resolves from authenticate

### DIFF
--- a/tina/config.tsx
+++ b/tina/config.tsx
@@ -53,6 +53,10 @@ if (!isLocal) {
           },
         },
       });
+      return new Promise(() => {
+          // This promise never resolves because Clerk redirects to
+          // the redirectUrl above
+      })
     },
     getUser: async () => {
       await clerk.load();


### PR DESCRIPTION
The [caller](https://github.com/tinacms/tinacms/blob/main/packages/tinacms/src/auth/TinaCloudProvider.tsx#L132) expects a promise but since with clerk are popping a modal and immediately returning, onAuthSuccess() will get called early and an error will occur. Fix the issue by returning a promise that never resolves.